### PR TITLE
fix for SimplePluginManager#unregister_events_for

### DIFF
--- a/src/bukkit/plugin/simple_plugin_manager.rb
+++ b/src/bukkit/plugin/simple_plugin_manager.rb
@@ -4,8 +4,6 @@ class org::bukkit::plugin::SimplePluginManager
   # Hack: No exposure to commandMap and I don't want to hack in new plugin manager type
   field_reader :commandMap => :command_map
   
-#  field_reader :listeners
-  
   # We either register a new command of infect the existing one with the
   # new commands state if the command has already been registered.
   def add_command(command, prefix="purugin")
@@ -17,14 +15,8 @@ class org::bukkit::plugin::SimplePluginManager
     end
   end
 
-  # Hack to unregister all events for a particular plugin
+  # unregister all events for a particular plugin
   def unregister_events_for(plugin)
-#    listeners.values.each do |type_set|
-#      type_set.to_a.each do |item|
-#        if item.plugin == plugin
-#          type_set.remove item 
-#        end
-#      end
-#    end
+    org.bukkit.event.HandlerList.unregisterAll plugin
   end
 end


### PR DESCRIPTION
They included a way to unregister listeners by plugin in bukkit now.

Feel free to refuse the request and implement it as you like, just thought this is the quickest way to point it out ;)
