### PR TITLE
Save purogo default directory as a relative path from CWD

### DIFF
--- a/examples/purogo.rb
+++ b/examples/purogo.rb
@@ -292,6 +292,8 @@ class PurogoPlugin
 
   def on_enable
     default = File.join(File.dirname(__FILE__), "purogo")
+    cwd = Dir.getwd + '/'
+    default.slice!(cwd) if default.start_with? cwd # as a relative path
     @purogo_directory = config.get!("purogo.directory", default)
     @ip_mode = false # hack this out for now. config.get!("purogo.ipmode", true)
     sessions = TurtleSessions.new @purogo_directory


### PR DESCRIPTION
See #32.
It's not very beautiful but requiring Pathname or such for a "relative_path_from" seems overkill.

Also it might fail if Dir.pwd returned a non symlink-expanded path but `__FILE__` did (or the reverse).
Hopefully this does not seem to happen (they are both fully expanded).
