### PR TITLE
Allow non-plugins to include Purugin::Task

### DIFF
--- a/src/main/resources/purugin/tasks.rb
+++ b/src/main/resources/purugin/tasks.rb
@@ -1,5 +1,7 @@
 require 'java'
 
+import 'org.bukkit.Bukkit'
+
 module Purugin
   # Set of tasks for scheduling synchronous or asynchronous tasks.  Note, that most of
   # the underlying Bukkit API in which Purugin is based is not actually thread-safe.  Try
@@ -19,9 +21,9 @@ module Purugin
       
       if repeat > -1
         raise ArgumentError.new "repeat must be positive value" if repeat <= 0
-        task_id = server.scheduler.schedule_sync_repeating_task self, code, delay, repeat
+        task_id = Bukkit.server.scheduler.schedule_sync_repeating_task self, code, delay, repeat
       else
-        task_id = server.scheduler.schedule_sync_delayed_task self, code, delay
+        task_id = Bukkit.server.scheduler.schedule_sync_delayed_task self, code, delay
       end
       
       raise Purugin::ScheduleFailedError.new if task_id == -1
@@ -36,9 +38,9 @@ module Purugin
       
       if repeat > -1
         raise ArgumentError.new "repeat must be positive value" if repeat <= 0
-        task_id = server.scheduler.schedule_async_repeating_task self, code, delay, repeat
+        task_id = Bukkit.server.scheduler.schedule_async_repeating_task self, code, delay, repeat
       else
-        task_id = server.scheduler.schedule_async_delayed_task self, code, delay
+        task_id = Bukkit.server.scheduler.schedule_async_delayed_task self, code, delay
       end
       
       raise Purugin::ScheduleFailedError.new if task_id == -1


### PR DESCRIPTION
This was driving me nuts because I wanted to create a simple DSL for chaining "task" creation.  This fix allows for it.

(Extremely silly) DSL can be seen here: https://github.com/elight/purugin_server/blob/master/plugins/on_login_experiment.rb
